### PR TITLE
Bugfix S1-54

### DIFF
--- a/src/main/java/com/tbt/trainthebrain/QuestionEditController.java
+++ b/src/main/java/com/tbt/trainthebrain/QuestionEditController.java
@@ -219,7 +219,7 @@ public class QuestionEditController extends AppController implements Initializab
         VBox parent = (VBox) checkBox.getParent().getParent();
         TextArea answerTextArea = (TextArea) parent.getChildren().get(1);
 
-        return !answerTextArea.getText().isEmpty();
+        return !answerTextArea.getText().trim().isEmpty();
     }
 
     /**
@@ -377,10 +377,10 @@ public class QuestionEditController extends AppController implements Initializab
         VBox parent = (VBox) ta.getParent();
         // Get Child of type HBox (that contains our Text Nodes)
         for (Node child: parent.getChildren()) {
-            // Set Checkbox "is correct" to to not selected if answerText is now empty
+            // Set Checkbox "is correct" to not selected if answerText is now empty
             if (child instanceof AnchorPane) {
                 checkBox = ((CheckBox) ((AnchorPane) child).getChildren().get(1));
-                if(ta.getText().isEmpty()) {
+                if(ta.getText().trim().isEmpty()) {
                     checkBox.setSelected(false);
                     checkBox.setDisable(true);
                 }else{


### PR DESCRIPTION
Es wurde ein Fehler behoben bei dem es möglich war im GUI eine Antwort als korrekt zu markieren wenngleich nur Leerschläge als Antworttext enthalten sind.

Zusätzlicher Check für die Speicherung der Antwort erstellt --> Text wird auch hier mit Trim geprüft